### PR TITLE
Harden onExpandScroll and onShrinkScroll handlers

### DIFF
--- a/src/detection-strategy/scroll.js
+++ b/src/detection-strategy/scroll.js
@@ -406,11 +406,21 @@ module.exports = function(options) {
             rootContainer.appendChild(containerContainer);
 
             function onExpandScroll() {
-                getState(element).onExpand && getState(element).onExpand();
+                var state = getState(element);
+                if (state && state.onExpand) {
+                    state.onExpand();
+                } else {
+                    debug("Aborting expand scroll handler: element has been uninstalled");
+                }
             }
 
             function onShrinkScroll() {
-                getState(element).onShrink && getState(element).onShrink();
+                var state = getState(element);
+                if (state && state.onShrink) {
+                    state.onShrink();
+                } else {
+                    debug("Aborting shrink scroll handler: element has been uninstalled");
+                }
             }
 
             addEvent(expand, "scroll", onExpandScroll);


### PR DESCRIPTION
FYI We have been using our fork with just this small addition since 2016.
I don't know the exact circumstances nor could I provide a reproducible example, so I'd understand if you reject the PR, but I figured I'd try to push this small change upstream, given that it should be harmless.